### PR TITLE
Set `type: module` in `package.json` to reduce warnings

### DIFF
--- a/package.json
+++ b/package.json
@@ -2,6 +2,7 @@
   "name": "@sourcemeta/registry",
   "private": true,
   "version": "0.0.0",
+  "type": "module",
   "dependencies": {
     "@codemirror/commands": "^6.8.1",
     "@codemirror/highlight": "^0.19.8",


### PR DESCRIPTION
Signed-off-by: Juan Cruz Viotti <jv@jviotti.com>
