### PR TITLE
Stop requiring a path in `Configuration::parse()`

### DIFF
--- a/src/configuration/include/sourcemeta/registry/configuration.h
+++ b/src/configuration/include/sourcemeta/registry/configuration.h
@@ -17,8 +17,7 @@ struct Configuration {
   static auto read(const std::filesystem::path &configuration_path,
                    const std::filesystem::path &collections_path)
       -> sourcemeta::core::JSON;
-  static auto parse(const std::filesystem::path &configuration_path,
-                    const sourcemeta::core::JSON &data) -> Configuration;
+  static auto parse(const sourcemeta::core::JSON &data) -> Configuration;
 
   sourcemeta::core::JSON::String url;
   sourcemeta::core::JSON::String title;

--- a/src/configuration/include/sourcemeta/registry/configuration_error.h
+++ b/src/configuration/include/sourcemeta/registry/configuration_error.h
@@ -12,28 +12,23 @@ namespace sourcemeta::registry {
 
 class ConfigurationValidationError : public std::exception {
 public:
-  ConfigurationValidationError(std::filesystem::path configuration_path,
-                               sourcemeta::core::Pointer pointer,
+  ConfigurationValidationError(sourcemeta::core::Pointer pointer,
                                std::string description)
-      : path_{std::move(configuration_path)}, pointer_{std::move(pointer)},
-        description_{std::move(description)} {}
+      : pointer_{std::move(pointer)}, description_{std::move(description)} {}
 
   [[nodiscard]] auto what() const noexcept -> const char * override {
     return "Invalid configuration";
   }
 
-  [[nodiscard]] auto path() const noexcept -> const auto & {
-    return this->path_;
-  }
   [[nodiscard]] auto pointer() const noexcept -> const auto & {
     return this->pointer_;
   }
+
   [[nodiscard]] auto description() const noexcept -> const auto & {
     return this->description_;
   }
 
 private:
-  const std::filesystem::path path_;
   const sourcemeta::core::Pointer pointer_;
   const std::string description_;
 };

--- a/src/index/index.cc
+++ b/src/index/index.cc
@@ -65,8 +65,8 @@ static auto index_main(const std::string_view &program,
   std::cerr << "Using configuration: " << configuration_path.string() << "\n";
   const auto raw_configuration{sourcemeta::registry::Configuration::read(
       configuration_path, SOURCEMETA_REGISTRY_COLLECTIONS)};
-  const auto configuration{sourcemeta::registry::Configuration::parse(
-      configuration_path, raw_configuration)};
+  const auto configuration{
+      sourcemeta::registry::Configuration::parse(raw_configuration)};
 
   // We want to keep this file uncompressed and without a leading header to that
   // the server can quickly read on start
@@ -444,8 +444,7 @@ auto main(int argc, char *argv[]) noexcept -> int {
     std::cerr << "error: " << error.what() << "\n  " << error.description()
               << "\n"
               << "    at location \""
-              << sourcemeta::core::to_string(error.pointer()) << "\"\n"
-              << "    at  " << error.path().string() << "\n";
+              << sourcemeta::core::to_string(error.pointer()) << "\"\n";
     return EXIT_FAILURE;
   } catch (const sourcemeta::registry::ValidatorError &error) {
     std::cerr << "error: " << error.what() << "\n" << error.stacktrace();

--- a/test/cli/common/index/invalid-configuration.sh
+++ b/test/cli/common/index/invalid-configuration.sh
@@ -30,7 +30,6 @@ Using configuration: $(realpath "$TMP")/registry.json
 error: Invalid configuration
   Missing 'url' required property
     at location ""
-    at  $(realpath "$TMP")/registry.json
 EOF
 
 diff "$TMP/output.txt" "$TMP/expected.txt"

--- a/test/unit/configuration/configuration_test.cc
+++ b/test/unit/configuration/configuration_test.cc
@@ -27,8 +27,8 @@ TEST(Configuration, stub_1) {
                                 "stub_1.json"};
   const auto raw_configuration{sourcemeta::registry::Configuration::read(
       configuration_path, COLLECTIONS_DIRECTORY)};
-  const auto configuration{sourcemeta::registry::Configuration::parse(
-      configuration_path, raw_configuration)};
+  const auto configuration{
+      sourcemeta::registry::Configuration::parse(raw_configuration)};
 
   EXPECT_EQ(configuration.url, "http://localhost:8000");
   EXPECT_EQ(configuration.title, "Title");

--- a/test/unit/resolver/resolver_test.cc
+++ b/test/unit/resolver/resolver_test.cc
@@ -11,8 +11,8 @@
       CONFIGURATION_PATH,                                                      \
       std::filesystem::path{CONFIGURATION_PATH}.parent_path() /                \
           "collections")};                                                     \
-  const auto configuration{sourcemeta::registry::Configuration::parse(         \
-      CONFIGURATION_PATH, raw_configuration)};
+  const auto configuration{                                                    \
+      sourcemeta::registry::Configuration::parse(raw_configuration)};
 
 #define RESOLVER_EXPECT(resolver, expected_uri, expected_schema)               \
   {                                                                            \


### PR DESCRIPTION
Signed-off-by: Juan Cruz Viotti <jv@jviotti.com>
