### PR TITLE
Add custom `mkdocs` CSS to avoid word-wrapping inline code in tables

### DIFF
--- a/docs/assets/style.css
+++ b/docs/assets/style.css
@@ -1,0 +1,4 @@
+/* To prevent weird table wrapping */
+table code {
+  white-space: nowrap;
+}

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -33,6 +33,8 @@ markdown_extensions:
   - pymdownx.details
   - pymdownx.superfences
   - footnotes
+extra_css:
+  - assets/style.css
 theme:
   language: en
   logo: assets/logo.svg


### PR DESCRIPTION
Signed-off-by: Juan Cruz Viotti <jv@jviotti.com>
